### PR TITLE
Add build label to daily OL images

### DIFF
--- a/full/java8/ibmjava/Dockerfile
+++ b/full/java8/ibmjava/Dockerfile
@@ -2,11 +2,13 @@
 FROM ibmjava:8-jre
 ARG LIBERTY_VERSION
 ARG LIBERTY_SHA
+ARG LIBERTY_BUILD_LABEL
 ARG LIBERTY_DOWNLOAD_URL
 
-LABEL maintainer="Alasdair Nottingham" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker.daily"
+LABEL maintainer="Arthur De Magalhaes" vendor="Open Liberty" url="https://openliberty.io/" github="https://github.com/OpenLiberty/ci.docker" \
+      BuildLabel="$LIBERTY_BUILD_LABEL"
 
-COPY docker-server /opt/ol/docker/
+COPY helpers /opt/ol/helpers
 
 # Install Open Liberty
 RUN apt-get update \
@@ -19,32 +21,55 @@ RUN apt-get update \
     && rm /tmp/wlp.zip \
     && rm /tmp/wlp.zip.sha1 \
     && apt-get remove -y unzip \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -u 1001 -r -g 0 -s /usr/sbin/nologin default \
+    && chown -R 1001:0 /opt/ol/wlp \
+    && chmod -R g+rw /opt/ol/wlp
 
 # Set Path Shortcuts
-ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:$PATH \
+ENV PATH=/opt/ol/wlp/bin:/opt/ol/docker/:/opt/ol/helpers/build:$PATH \
     LOG_DIR=/logs \
     WLP_OUTPUT_DIR=/opt/ol/wlp/output \
-    WLP_SKIP_MAXPERMSIZE=true \
-    KEYSTORE_REQUIRED=true
-
-RUN mkdir /logs \
-    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
-    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
-    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
-    && ln -s /logs $WLP_OUTPUT_DIR/defaultServer/logs \
-    && ln -s /liberty /opt/ol/wlp
+    WLP_SKIP_MAXPERMSIZE=true
 
 # Configure WebSphere Liberty
 RUN /opt/ol/wlp/bin/server create \
-    && rm /config/server.env \
-    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea \
-    && mkdir /config/configDropins \
-    && mkdir /config/configDropins/defaults \
-    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml \
-    && /opt/ol/wlp/bin/server start && /opt/ol/wlp/bin/server stop && rm -rf /output/resources/security/ && rm -rf /output/messaging /logs/*
+    && rm -rf $WLP_OUTPUT_DIR/.classCache /output/workarea
+
+
+# Create symlinks && set permissions for non-root user    
+RUN mkdir /logs \
+    && mkdir -p /opt/ol/wlp/usr/shared/resources/lib.index.cache \
+    && ln -s /opt/ol/wlp/usr/shared/resources/lib.index.cache /lib.index.cache \
+    && mkdir -p $WLP_OUTPUT_DIR/defaultServer \
+    && ln -s $WLP_OUTPUT_DIR/defaultServer /output \
+    && ln -s /opt/ol/wlp/usr/servers/defaultServer /config \
+    && mkdir -p /config/configDropins/defaults \
+    && mkdir -p /config/configDropins/overrides \
+    && ln -s /opt/ol/wlp /liberty \
+    && chown -R 1001:0 /config \
+    && chmod -R g+rw /config \
+    && chown -R 1001:0 /logs \
+    && chmod -R g+rw /logs \
+    && chown -R 1001:0 /opt/ol/wlp/usr \
+    && chmod -R g+rw /opt/ol/wlp/usr \
+    && chown -R 1001:0 /opt/ol/wlp/output \
+    && chmod -R g+rw /opt/ol/wlp/output \
+    && chown -R 1001:0 /opt/ol/helpers \
+    && chmod -R g+rw /opt/ol/helpers \
+    && mkdir /etc/wlp \
+    && chown -R 1001:0 /etc/wlp \
+    && chmod -R g+rw /etc/wlp \
+    && echo "<server description=\"Default Server\"><httpEndpoint id=\"defaultHttpEndpoint\" host=\"*\" /></server>" > /config/configDropins/defaults/open-default-port.xml
+
+
+#These settings are needed so that we can run as a different user than 1001 after server warmup
+ENV RANDFILE=/tmp/.rnd \
+    IBM_JAVA_OPTIONS="-Xshareclasses:name=liberty,nonfatal,cacheDir=/output/.classCache/ ${IBM_JAVA_OPTIONS}"
+
+USER 1001
 
 EXPOSE 9080 9443
 
-ENTRYPOINT ["/opt/ol/docker/docker-server"]
+ENTRYPOINT ["/opt/ol/helpers/runtime/docker-server.sh"]
 CMD ["/opt/ol/wlp/bin/server", "run", "defaultServer"]

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/hazelcast-client.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/hazelcast-client.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <redo-operation>true</redo-operation>
+    <discovery-strategies>
+      <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+      </discovery-strategy>
+    </discovery-strategies>
+  </network>
+</hazelcast-client>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/hazelcast-embedded.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/hazelcast-embedded.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+  <properties>
+    <property name="hazelcast.discovery.enabled">true</property>
+  </properties>
+  <network>
+    <join>
+      <multicast enabled="false"/>
+      <tcp-ip enabled="false"/>
+      <discovery-strategies>
+        <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
+        </discovery-strategy>
+      </discovery-strategies>
+    </join>
+  </network>
+</hazelcast>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/hazelcast-sessioncache.xml
@@ -1,0 +1,11 @@
+<server>
+  <featureManager>
+    <feature>sessionCache-1.0</feature>
+  </featureManager>
+  <httpSessionCache libraryRef="HazelcastLib">
+    <properties hazelcast.config.location="file:${shared.config.dir}/hazelcast/hazelcast.xml"/>
+  </httpSessionCache>
+  <library id="HazelcastLib">
+    <fileset dir="${shared.resource.dir}/hazelcast"/>
+  </library>
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/http-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/http-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" />
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/http-ssl-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/http-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="9443" httpPort="9080" />
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809" />
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809">
+        <iiopsOptions iiopsPort="9402" sslRef="defaultSSLConfig" />
+    </iiopEndpoint>
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/jms-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/jms-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsPort="7276" />
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsSSLPort="7286" />
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/mp-health-check.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/mp-health-check.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpHealth-1.0</feature>
+    </featureManager>
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/mp-monitoring.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/mp-monitoring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>mpMetrics-1.1</feature>
+        <feature>monitor-1.0</feature>
+    </featureManager>
+    
+    <mpMetrics authentication="false" />
+</server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/ssl.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <featureManager>
+        <feature>ssl-1.0</feature>
+    </featureManager>
+</server>

--- a/full/java8/ibmjava/helpers/build/configure.sh
+++ b/full/java8/ibmjava/helpers/build/configure.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -Eeox pipefail
+
+##Define variables for XML snippets source and target paths
+WLP_INSTALL_DIR=/opt/ol/wlp
+SHARED_CONFIG_DIR=${WLP_INSTALL_DIR}/usr/shared/config
+SHARED_RESOURCE_DIR=${WLP_INSTALL_DIR}/usr/shared/resources
+
+SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
+SNIPPETS_TARGET=/config/configDropins/overrides
+mkdir -p ${SNIPPETS_TARGET}
+
+
+#Check for each Liberty value-add functionality
+
+# MicroProfile Health
+if [ "$MP_HEALTH_CHECK" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-health-check.xml $SNIPPETS_TARGET/mp-health-check.xml
+fi
+
+# MicroProfile Monitoring
+if [ "$MP_MONITORING" == "true" ]; then
+  cp $SNIPPETS_SOURCE/mp-monitoring.xml $SNIPPETS_TARGET/mp-monitoring.xml
+fi
+
+# SSL
+if [ "$SSL" == "true" ]; then
+  cp $SNIPPETS_SOURCE/ssl.xml $SNIPPETS_TARGET/ssl.xml
+fi
+
+# HTTP Endpoint
+if [ "$HTTP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/http-ssl-endpoint.xml $SNIPPETS_TARGET/http-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/http-endpoint.xml $SNIPPETS_TARGET/http-endpoint.xml
+  fi
+fi
+
+# Hazelcast Session Caching
+if [ "${HZ_SESSION_CACHE}" == "client" ] || [ "${HZ_SESSION_CACHE}" == "embedded" ]
+then
+ cp ${SNIPPETS_SOURCE}/hazelcast-sessioncache.xml ${SNIPPETS_TARGET}/hazelcast-sessioncache.xml
+ mkdir -p ${SHARED_CONFIG_DIR}/hazelcast
+ cp ${SNIPPETS_SOURCE}/hazelcast-${HZ_SESSION_CACHE}.xml ${SHARED_CONFIG_DIR}/hazelcast/hazelcast.xml
+fi
+
+# IIOP Endpoint
+if [ "$IIOP_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/iiop-ssl-endpoint.xml $SNIPPETS_TARGET/iiop-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/iiop-endpoint.xml $SNIPPETS_TARGET/iiop-endpoint.xml
+  fi
+fi
+
+# JMS Endpoint
+if [ "$JMS_ENDPOINT" == "true" ]; then
+  if [ "$SSL" == "true" ]; then
+    cp $SNIPPETS_SOURCE/jms-ssl-endpoint.xml $SNIPPETS_TARGET/jms-ssl-endpoint.xml
+  else
+    cp $SNIPPETS_SOURCE/jms-endpoint.xml $SNIPPETS_TARGET/jms-endpoint.xml
+  fi
+fi

--- a/full/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/full/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -11,7 +11,12 @@ then
     if [ ! -e $keystorePath ]
     then
       # Generate the keystore.xml
-      export keystore_password=$(openssl rand -base64 32)
+      export PASSWORD=$(openssl rand -base64 32)
+      XML="<server description=\"Default Server\"><keyStore id=\"defaultKeyStore\" password=\"$PASSWORD\" /></server>"
+
+    # Create the keystore.xml file and place in configDropins
+    mkdir -p $(dirname $keystorePath)
+    echo $XML > $keystorePath
     fi
   fi
 fi


### PR DESCRIPTION
Adding the build label to the Open Liberty daily image labels, to match each image to the development driver it was generated from.

Also updating the full Dockerfile, because it had fallen behind the rest of the images in ci.docker.