### PR TITLE
add variables to config files

### DIFF
--- a/full/java8/ibmjava/helpers/build/configuration_snippets/http-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/http-endpoint.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server>
-    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" />
+    <variable name="HTTP_PORT" defaultValue="9080" />
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="${HTTP_PORT}"/>
 </server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/http-ssl-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/http-ssl-endpoint.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server>
-    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="9443" httpPort="9080" />
+    <variable name="HTTP_PORT" defaultValue="9080" />
+    <variable name="HTTPS_PORT" defaultValue="9443" />
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="${HTTPS_PORT}" httpPort="${HTTP_PORT}" />
 </server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-endpoint.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server>
-    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809" />
+    <variable name="IIOP_PORT" defaultValue="2809" />
+    <iiopEndpoint id="defaultIiopEndpoint" host="${IIOP_ENDPOINT_HOST}" iiopPort="${IIOP_PORT}" />
 </server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/iiop-ssl-endpoint.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server>
-    <iiopEndpoint id="defaultIiopEndpoint" host="${env.IIOP_ENDPOINT_HOST}" iiopPort="2809">
-        <iiopsOptions iiopsPort="9402" sslRef="defaultSSLConfig" />
+    <variable name="IIOP_PORT" defaultValue="2809" />
+    <variable name="IIOPS_PORT" defaultValue="9402" />
+    <iiopEndpoint id="defaultIiopEndpoint" host="${IIOP_ENDPOINT_HOST}" iiopPort="${IIOP_PORT}">
+        <iiopsOptions iiopsPort="${IIOPS_PORT}" sslRef="defaultSSLConfig" />
     </iiopEndpoint>
 </server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/jms-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/jms-endpoint.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server>
-    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsPort="7276" />
+    <variable name="JMS_PORT" defaultValue="7276" />
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsPort="${JMS_PORT}" />
 </server>

--- a/full/java8/ibmjava/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
+++ b/full/java8/ibmjava/helpers/build/configuration_snippets/jms-ssl-endpoint.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <server>
-    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsSSLPort="7286" />
+    <variable name="JMSS_PORT" defaultValue="7286" />
+    <wasJmsEndpoint id="InboundJmsEndpoint" host="*" wasJmsSSLPort="${JMSS_PORT}" />
 </server>


### PR DESCRIPTION
Open Liberty Docker images had HTTP/JMS/IIOP ports hard coded. For [example](https://github.ibm.com/was-docker/build-liberty-images-ubi/blob/3ff1b1f96ea52778a56c73b091520399dfab02ff/ol/19.0.0.x/kernel/java8/ibmsfj/helpers/build/configuration_snippets/http-ssl-endpoint.xml#L3):

```
<?xml version="1.0" encoding="UTF-8"?>
<server>
    <httpEndpoint id="defaultHttpEndpoint" host="*" httpsPort="9443" httpPort="9080" />
</server>
```

Liberty 19.0.0.3 now allows user to specify the port variables. For example: user can now use `ENV HTTP_PORT=9081` in their `Dockerfile` to override the default values.

This PR changed the HTTP/JMS/IIOP configuration files to allow the customization.

For more information about server configuration, please refer to the [Server configuration overview](https://openliberty.io/docs/ref/config/serverConfiguration.html)