### PR TITLE
Update helper files for full-java8-ibm

### DIFF
--- a/full/java8/ibmjava/helpers/runtime/docker-server.sh
+++ b/full/java8/ibmjava/helpers/runtime/docker-server.sh
@@ -3,23 +3,27 @@
 set -e
 
 SNIPPETS_SOURCE=/opt/ol/helpers/build/configuration_snippets
-SNIPPETS_TARGET=/config/configDropins/overrides
+SNIPPETS_TARGET_DEFAULTS=/config/configDropins/defaults
+SNIPPETS_TARGET_OVERRIDES=/config/configDropins/overrides
 
-keystorePath="$SNIPPETS_TARGET/keystore.xml"
+keystorePath="$SNIPPETS_TARGET_DEFAULTS/keystore.xml"
 
-if [ "$SSL" == "true" ] || [ "$TLS" == "true" ]
+if [ "$SSL" = "true" ] || [ "$TLS" = "true" ]
 then
-  if [ "$1" = "server" ] || [ "$1" = "/opt/ol/wlp/bin/server" ]
+  cp $SNIPPETS_SOURCE/tls.xml $SNIPPETS_TARGET_OVERRIDES/tls.xml
+fi
+
+if [ "$SSL" != "false" ] && [ "$TLS" != "false" ]
+then
+  if [ ! -e $keystorePath ]
   then
-    if [ ! -e $keystorePath ]
-    then
-      # Generate the keystore.xml
-      export KEYSTOREPWD=$(openssl rand -base64 32)
-      sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
-      cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET/keystore.xml
-    fi
+    # Generate the keystore.xml
+    export KEYSTOREPWD=$(openssl rand -base64 32)
+    sed -i.bak "s|REPLACE|$KEYSTOREPWD|g" $SNIPPETS_SOURCE/keystore.xml
+    cp $SNIPPETS_SOURCE/keystore.xml $SNIPPETS_TARGET_DEFAULTS/keystore.xml
   fi
 fi
+
 
 # Pass on to the real server run
 exec "$@"


### PR DESCRIPTION
- Fixes bug with docker-server.sh with a syntax incompatibility between sh and bash.
- Updates docker-server.sh to match other open liberty images
- Fixes [#121](https://github.com/OpenLiberty/ci.docker/issues/121)