### PR TITLE
Update the Script for JDK 14 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/OpenLiberty/ci.docker.daily.svg?branch=master)](https://travis-ci.org/OpenLiberty/ci.docker.daily)
+
 # ci.docker.daily
 Daily development builds of the Open Liberty Docker images.
 

--- a/build.sh
+++ b/build.sh
@@ -66,8 +66,8 @@ build_latest_tag() {
     local tag="$1"
     local tag_label="full"
     # set image information arrays
-    local file_exts_ubi=(ubi.adoptopenjdk8 ubi.adoptopenjdk11 ubi.adoptopenjdk13 ubi.ibmjava8 ubuntu.adoptopenjdk8)
-    local tag_exts_ubi=(java8-openj9-ubi java11-openj9-ubi java13-openj9-ubi java8-ibmjava-ubi java8-openj9)
+    local file_exts_ubi=(ubi.adoptopenjdk8 ubi.adoptopenjdk11 ubi.adoptopenjdk14 ubi.ibmjava8 ubuntu.adoptopenjdk8)
+    local tag_exts_ubi=(java8-openj9-ubi java11-openj9-ubi java14-openj9-ubi java8-ibmjava-ubi java8-openj9)
 
     for i in "${!tag_exts_ubi[@]}"; do
         local docker_dir="${IMAGE_ROOT}/${version}/${tag}"


### PR DESCRIPTION
Changed jdk13->jdk14 in scripts.
Updated the submodule, ci.docker. 
Added Travis build status icon to the README file.