### PR TITLE
Updates for 20.0.0.11 and correct image tag from kernel to full

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ main () {
         echo "$DOCKERPWD" | docker login -u "$DOCKERID" --password-stdin
     fi
 
-    local tags=(kernel)
+    local tags=(full)
 
     for tag in "${tags[@]}"; do
       build_latest_tag $tag


### PR DESCRIPTION
First pass of updates for 20.0.0.11. Kick the submodule up and fix the name of the tag we're using to be full not kernel.